### PR TITLE
Fix locking issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+*.sqlite3
+
+# Folders
+_obj
+_test
+.idea
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+tags
+
+# Emacs artifacts
+*~
+\#*\#
+.\#*\#
+
+# Eclipse artifacts
+.project

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -483,7 +483,7 @@ func (s *Consul) renewLockSession(initialTTL string, id string, stopRenew chan s
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *consulLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+func (l *consulLock) Lock(stopChan <-chan struct{}) (<-chan struct{}, error) {
 	return l.lock.Lock(stopChan)
 }
 

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -496,8 +496,11 @@ func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
 		}
 
 		setOpts.PrevExist = etcd.PrevExist
-		l.last, err = l.client.Set(context.Background(), l.key, l.value, setOpts)
-
+		var lastResp *etcd.Response
+		lastResp, err = l.client.Set(context.Background(), l.key, l.value, setOpts)
+		if lastResp != nil {
+			l.last = lastResp
+		}
 		if err == nil {
 			// Leader section
 			l.stopLock = stopLocking
@@ -575,7 +578,7 @@ func (l *etcdLock) waitLock(key string, errorCh chan error, stopWatchCh chan boo
 			errorCh <- err
 			return
 		}
-		if event.Action == "delete" || event.Action == "expire" {
+		if event.Action == "delete" || event.Action == "expire" || event.Action == "compareAndDelete" {
 			free <- true
 			return
 		}

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -471,7 +471,7 @@ func (s *Etcd) NewLock(key string, options *store.LockOptions) (lock store.Locke
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+func (l *etcdLock) Lock(stopChan <-chan struct{}) (<-chan struct{}, error) {
 
 	// Lock holder channel
 	lockHeld := make(chan struct{})

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -10,13 +11,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	client = "localhost:4001"
+const (
+	defaultEndpoint = "localhost:4001"
+	endpointEnvVar  = "LIBKV_TEST_ETCD_ENDPOINT"
 )
 
+// makeEtcdClient makes etcd client for use in tests. It uses
+// defaultEndpoint, unless LIBKV_TEST_ETCD_ENDPOINT environment
+// variable is specified, in which case it is used.
 func makeEtcdClient(t *testing.T) store.Store {
+	endpoint := os.Getenv(endpointEnvVar)
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+
+	t.Logf("Using ETCD endpoint %s", endpoint)
 	kv, err := New(
-		[]string{client},
+		[]string{endpoint},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
 			Username:          "test",
@@ -33,8 +44,12 @@ func makeEtcdClient(t *testing.T) store.Store {
 
 func TestRegister(t *testing.T) {
 	Register()
-
-	kv, err := libkv.NewStore(store.ETCD, []string{client}, nil)
+	endpoint := os.Getenv(endpointEnvVar)
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	t.Logf("Using ETCD endpoint %s", endpoint)
+	kv, err := libkv.NewStore(store.ETCD, []string{endpoint}, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, kv)
 
@@ -54,5 +69,7 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
 	testutils.RunTestTTL(t, kv, ttlKV)
+
 	testutils.RunCleanup(t, kv)
+
 }

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -58,6 +58,12 @@ func TestRegister(t *testing.T) {
 	}
 }
 
+func TestEtcdStoreConcurrentLock(t *testing.T) {
+	kv := makeEtcdClient(t)
+	testutils.RunTestLockConcurrent(t, kv)
+	testutils.RunCleanup(t, kv)
+}
+
 func TestEtcdStore(t *testing.T) {
 	kv := makeEtcdClient(t)
 	lockKV := makeEtcdClient(t)
@@ -69,7 +75,5 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
 	testutils.RunTestTTL(t, kv, ttlKV)
-
 	testutils.RunCleanup(t, kv)
-
 }

--- a/store/mock/mock.go
+++ b/store/mock/mock.go
@@ -96,7 +96,7 @@ type Lock struct {
 }
 
 // Lock mock
-func (l *Lock) Lock(stopCh chan struct{}) (<-chan struct{}, error) {
+func (l *Lock) Lock(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	args := l.Mock.Called(stopCh)
 	return args.Get(0).(<-chan struct{}), args.Error(1)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -127,6 +127,6 @@ type LockOptions struct {
 // Locker provides locking mechanism on top of the store.
 // Similar to `sync.Lock` except it may return errors.
 type Locker interface {
-	Lock(stopChan chan struct{}) (<-chan struct{}, error)
+	Lock(stopChan <-chan struct{}) (<-chan struct{}, error)
 	Unlock() error
 }

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -398,7 +398,7 @@ func (s *Zookeeper) NewLock(key string, options *store.LockOptions) (lock store.
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *zookeeperLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+func (l *zookeeperLock) Lock(stopChan <-chan struct{}) (<-chan struct{}, error) {
 	err := l.lock.Lock()
 
 	if err == nil {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -53,6 +53,7 @@ func RunTestTTL(t *testing.T, kv store.Store, backup store.Store) {
 func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 	// Get a not exist key should return ErrKeyNotFound
 	pair, err := kv.Get("testPutGetDelete_not_exist_key")
+	t.Logf("testPutGetDeleteExists: Got %s.(%T)", err, err)
 	assert.Equal(t, store.ErrKeyNotFound, err)
 
 	value := []byte("bar")


### PR DESCRIPTION
1. Fixes https://github.com/docker/libkv/issues/176
2. Fixes https://github.com/docker/libkv/issues/177
3. Allows for an env var to override default etcd endpoint for testing